### PR TITLE
Fix non-secure schemes from https to http

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -283,7 +283,7 @@ spec: WEBIDL; urlPrefix: https://heycam.github.io/webidl/
     <svg width="400" height="400">
       <g transform="translate(10,10)">
         <rect height="175" width="297" y="0" x="0" class="non-secure" />
-        <text transform="translate(10, 20)">https://non-secure.example.com/</text>
+        <text transform="translate(10, 20)">http://non-secure.example.com/</text>
       </g>
       <g transform="translate(10,210)">
         <rect height="175" width="297" y="0" x="0" class="non-secure" />
@@ -308,7 +308,7 @@ spec: WEBIDL; urlPrefix: https://heycam.github.io/webidl/
     <svg width="400" height="400">
       <g transform="translate(10,10)">
         <rect height="175" width="297" y="0" x="0" class="non-secure" />
-        <text transform="translate(10, 20)">https://non-secure.example.com/</text>
+        <text transform="translate(10, 20)">http://non-secure.example.com/</text>
       </g>
       <g transform="translate(10,210)">
         <rect height="175" width="297" y="0" x="0" class="secure" />


### PR DESCRIPTION
I found it while translating this spec into Japanese.

Each `non-secure.example.com` in other examples has `http:` schemes, so I suppose `https://non-secure.example.com` in Example 4 should also have `http:` schemes ...?

Thanks!
