### PR TITLE
Drop the sandbox flag.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1221,9 +1221,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version d2febad00f62a578fcdd0d902104eb698a01e002" name="generator">
+  <meta content="Bikeshed version b43aa594f5014ff14748da1aace9afaa73d2b3e6" name="generator">
   <link href="https://www.w3.org/TR/secure-contexts/" rel="canonical">
-  <meta content="3fbc1bbdfa52212827e4c816a321d3b40c9a0d9b" name="document-revision">
+  <meta content="1e2694ff640bcd5223d5d946cb9f1b5740a1d4fc" name="document-revision">
 <style>
     .secure {
       fill: #8F8;
@@ -1552,13 +1552,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <p> This document is governed by the <a href="https://www.w3.org/2019/Process-20190301/" id="w3c_process_revision">1 March 2019 W3C Process Document</a>. </p>
    <p></p>
   </div>
-  <div data-fill-with="at-risk">
-   <p>The following features are at-risk, and may be dropped during the CR period: </p>
-   <ul>
-    <li>The <a data-link-type="dfn" href="#sandboxed-secure-browsing-context-flag" id="ref-for-sandboxed-secure-browsing-context-flag">sandboxed secure browsing context flag</a> defined in <a href="#monkey-patching-sandbox-flags">§ 2.2.1 Sandboxing</a>, as well as its usage in <a href="#is-settings-object-contextually-secure">§ 3.1 Is an environment settings object contextually secure?</a>.
-   </ul>
-   <p>“At-risk” is a W3C Process term-of-art, and does not necessarily imply that the feature is in danger of being dropped or delayed. It means that the WG believes the feature may have difficulty being interoperably implemented in a timely manner, and marking it as such allows the WG to drop the feature if necessary when transitioning to the Proposed Rec stage, without having to publish a new Candidate Rec without the feature first.</p>
-  </div>
+  <div data-fill-with="at-risk"></div>
   <nav data-fill-with="table-of-contents" id="toc">
    <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
    <ol class="toc" role="directory">
@@ -1578,9 +1572,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
       <li>
        <a href="#monkey-patching-html"><span class="secno">2.2</span> <span class="content">Modifications to HTML</span></a>
        <ol class="toc">
-        <li><a href="#monkey-patching-sandbox-flags"><span class="secno">2.2.1</span> <span class="content">Sandboxing</span></a>
-        <li><a href="#shared-workers"><span class="secno">2.2.2</span> <span class="content">Shared Workers</span></a>
-        <li><a href="#monkey-patching-global-object"><span class="secno">2.2.3</span> <span class="content">Feature Detection</span></a>
+        <li><a href="#shared-workers"><span class="secno">2.2.1</span> <span class="content">Shared Workers</span></a>
+        <li><a href="#monkey-patching-global-object"><span class="secno">2.2.2</span> <span class="content">Feature Detection</span></a>
        </ol>
      </ol>
     <li>
@@ -1994,35 +1987,16 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <p>Specification authors are encouraged to use this attribute when defining new
     features.</p>
      <h3 class="heading settled" data-level="2.2" id="monkey-patching-html"><span class="secno">2.2. </span><span class="content">Modifications to HTML</span><a class="self-link" href="#monkey-patching-html"></a></h3>
-     <h4 class="heading settled" data-level="2.2.1" id="monkey-patching-sandbox-flags"><span class="secno">2.2.1. </span><span class="content">Sandboxing</span><a class="self-link" href="#monkey-patching-sandbox-flags"></a></h4>
-     <p>Developers may wish to treat sandboxed <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing contexts</a> as <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts①⑦">secure
-    contexts</a> in some situations, and <a data-link-type="dfn" href="#non-secure-contexts" id="ref-for-non-secure-contexts①">non-secure contexts</a> in others. The
-    following sandboxing flag supports this desire:</p>
-     <dl>
-      <dt>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="sandboxed-secure-browsing-context-flag">sandboxed secure browsing context flag</dfn>
-      <dd> This flag asserts that content in a browsing context will be treated as a <a data-link-type="dfn" href="#non-secure-contexts" id="ref-for-non-secure-contexts②">non-secure context</a>, even if it would otherwise be considered secure. 
-     </dl>
-     <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive" id="ref-for-parse-a-sandboxing-directive">parse a sandboxing directive</a> algorithm is extended by adding the
-    following entry to the list in the final step of the algorithm which parses <var>tokens</var> into flags:</p>
-     <ul>
-      <li data-md>
-       <p>The <a data-link-type="dfn" href="#sandboxed-secure-browsing-context-flag" id="ref-for-sandboxed-secure-browsing-context-flag①">sandboxed secure browsing context flag</a>, unless <var>tokens</var> contains the <dfn data-dfn-for="iframe/sandbox" data-dfn-type="attr-value" data-export id="attr-valuedef-iframe-sandbox-allow-secure-context"><code>allow-secure-context</code><a class="self-link" href="#attr-valuedef-iframe-sandbox-allow-secure-context"></a></dfn> keyword.</p>
-     </ul>
-     <p class="issue" id="issue-7a8465db"><a class="self-link" href="#issue-7a8465db"></a> This feature is "at risk", pending the
-    resolution of the linked issue (which itself is pending metrics gathered from
-    browser vendors). Accordingly, no attempt has been made to upstream this to
-    either WHATWG’s HTML or W3C’s HTML. Once we’ve decided whether or not to keep
-    the feature, we’ll work on that. <a href="https://github.com/w3c/webappsec-secure-contexts/issues/28">&lt;https://github.com/w3c/webappsec-secure-contexts/issues/28></a></p>
-     <h4 class="non-normative heading settled" data-level="2.2.2" id="shared-workers"><span class="secno">2.2.2. </span><span class="content">Shared Workers</span><a class="self-link" href="#shared-workers"></a></h4>
+     <h4 class="non-normative heading settled" data-level="2.2.1" id="shared-workers"><span class="secno">2.2.1. </span><span class="content">Shared Workers</span><a class="self-link" href="#shared-workers"></a></h4>
      <p><em>This section is non-normative</em>.</p>
      <p>The <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker" id="ref-for-sharedworker">SharedWorker</a></code> constructor will throw a <code>SecurityError</code> exception if
-    a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts①⑧">secure context</a> attempts to attach to an Worker which is not a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts①⑨">secure context</a>, and if a non-secure context attempts to attach to a
-    Worker which is a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②⓪">secure context</a>.</p>
+    a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts①⑦">secure context</a> attempts to attach to an Worker which is not a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts①⑧">secure context</a>, and if a non-secure context attempts to attach to a
+    Worker which is a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts①⑨">secure context</a>.</p>
      <p class="issue" id="issue-84914d73"><a class="self-link" href="#issue-84914d73"></a> This is currently defined in Step 11.4.2 of the WHATWG’s HTML (landed in <a href="https://github.com/whatwg/html/pull/1560">whatwg/html#1560</a>. It has not yet been
     picked up by the W3C’s version of that algorithm. <a href="https://github.com/w3c/workers/issues/6">&lt;https://github.com/w3c/workers/issues/6></a></p>
     </section>
-    <h4 class="heading settled" data-level="2.2.3" id="monkey-patching-global-object"><span class="secno">2.2.3. </span><span class="content">Feature Detection</span><a class="self-link" href="#monkey-patching-global-object"></a></h4>
-    <p>An application can determine determine whether it’s executing in a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②①">secure context</a> by checking
+    <h4 class="heading settled" data-level="2.2.2" id="monkey-patching-global-object"><span class="secno">2.2.2. </span><span class="content">Feature Detection</span><a class="self-link" href="#monkey-patching-global-object"></a></h4>
+    <p>An application can determine determine whether it’s executing in a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②⓪">secure context</a> by checking
   a simple boolean attribute on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object" id="ref-for-global-object①">global object</a>:</p>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope" id="ref-for-windoworworkerglobalscope"><c- g>WindowOrWorkerGlobalScope</c-></a> {
   <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="WindowOrWorkerGlobalScope" data-dfn-type="attribute" data-export data-readonly data-type="boolean" id="dom-windoworworkerglobalscope-issecurecontext"><code><c- g>isSecureContext</c-></code></dfn>;
@@ -2053,8 +2027,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
        <li data-md>
         <p>Return "<code>Secure</code>".</p>
         <p class="note" role="note"><span>Note:</span> Given the assertion above, if we’ve reached this step, the
-  worker must have been created from a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②②">secure context</a>, and
-  therefore must itself be a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②③">secure context</a>.</p>
+  worker must have been created from a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②①">secure context</a>, and
+  therefore must itself be a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②②">secure context</a>.</p>
       </ol>
      <li data-md>
       <p class="assertion">Assert: <var>global</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window①">Window</a></code>.</p>
@@ -2064,14 +2038,11 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
       <p>Return "<code>Not Secure</code>" if any of the following are true:</p>
       <ol>
        <li data-md>
-        <p><var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#active-sandboxing-flag-set" id="ref-for-active-sandboxing-flag-set">active sandboxing flag set</a> contains the <a data-link-type="dfn" href="#sandboxed-secure-browsing-context-flag" id="ref-for-sandboxed-secure-browsing-context-flag②">sandboxed secure browsing context flag</a>.</p>
-        <p class="note" role="note"><span>Note:</span> This check is "at risk". See <a href="#monkey-patching-sandbox-flags">§ 2.2.1 Sandboxing</a> for details.</p>
-       <li data-md>
         <p><var>document</var> has a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context" id="ref-for-parent-browsing-context">parent browsing context</a> (<var>context</var>), and <var>context</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active document</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object" id="ref-for-relevant-settings-object⑤">relevant settings object</a> is not <a data-link-type="dfn" href="#environment-settings-object-contextually-secure" id="ref-for-environment-settings-object-contextually-secure④">contextually secure</a>.</p>
        <li data-md>
         <p><var>settings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state" id="ref-for-https-state②">HTTPS state</a> is "<code>deprecated</code>".</p>
        <li data-md>
-        <p><var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#active-sandboxing-flag-set" id="ref-for-active-sandboxing-flag-set①">active sandboxing flag set</a> includes the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-origin-browsing-context-flag" id="ref-for-sandboxed-origin-browsing-context-flag">sandboxed origin browsing context flag</a>, and <a href="#is-url-trustworthy">§ 3.3 Is url potentially trustworthy?</a> returns "<code>Not Trustworthy</code>" when executed upon <var>settings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url" id="ref-for-concept-environment-creation-url">creation URL</a>.</p>
+        <p><var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#active-sandboxing-flag-set" id="ref-for-active-sandboxing-flag-set">active sandboxing flag set</a> includes the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-origin-browsing-context-flag" id="ref-for-sandboxed-origin-browsing-context-flag">sandboxed origin browsing context flag</a>, and <a href="#is-url-trustworthy">§ 3.3 Is url potentially trustworthy?</a> returns "<code>Not Trustworthy</code>" when executed upon <var>settings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url" id="ref-for-concept-environment-creation-url">creation URL</a>.</p>
         <p class="note" role="note"><span>Note:</span> We check the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url" id="ref-for-concept-environment-creation-url①">creation URL</a> here because sandboxed content
   that is treated as being in an opaque origin (e.g. <code>&lt;iframe sandbox="allow-secure-context" src="http://127.0.0.1/"></code>)
   would otherwise be treated as non-trustworthy by <a href="#is-origin-trustworthy">§ 3.2 Is origin potentially trustworthy?</a>. Since sandboxing is a strict reduction in
@@ -2079,7 +2050,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   look at the origin of its URL to determine whether we would have
   considered it trustworthy had it not been sandboxed.</p>
        <li data-md>
-        <p><var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#active-sandboxing-flag-set" id="ref-for-active-sandboxing-flag-set②">active sandboxing flag set</a> does not include the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-origin-browsing-context-flag" id="ref-for-sandboxed-origin-browsing-context-flag①">sandboxed origin browsing context flag</a>, and <a href="#is-origin-trustworthy">§ 3.2 Is origin potentially trustworthy?</a> returns "<code>Not Trustworthy</code>" when executed
+        <p><var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#active-sandboxing-flag-set" id="ref-for-active-sandboxing-flag-set①">active sandboxing flag set</a> does not include the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-origin-browsing-context-flag" id="ref-for-sandboxed-origin-browsing-context-flag①">sandboxed origin browsing context flag</a>, and <a href="#is-origin-trustworthy">§ 3.2 Is origin potentially trustworthy?</a> returns "<code>Not Trustworthy</code>" when executed
   upon <var>settings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin②">origin</a>.</p>
       </ol>
      <li data-md>
@@ -2136,7 +2107,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <li data-md>
       <p>Return "<code>Not Trustworthy</code>".</p>
     </ol>
-    <p class="note" role="note"><span>Note:</span> Neither <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-domain" id="ref-for-concept-origin-domain">domain</a> nor <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-port" id="ref-for-concept-origin-port">port</a> has any effect on whether or not it is considered to be a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②④">secure context</a>.</p>
+    <p class="note" role="note"><span>Note:</span> Neither <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-domain" id="ref-for-concept-origin-domain">domain</a> nor <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-port" id="ref-for-concept-origin-port">port</a> has any effect on whether or not it is considered to be a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②③">secure context</a>.</p>
     <h3 class="heading settled" data-level="3.3" id="is-url-trustworthy"><span class="secno">3.3. </span><span class="content"> Is <var>url</var> potentially trustworthy? </span><a class="self-link" href="#is-url-trustworthy"></a></h3>
     <p>A <dfn data-dfn-type="dfn" data-export id="potentially-trustworthy-url">potentially trustworthy URL<a class="self-link" href="#potentially-trustworthy-url"></a></dfn> is one which either inherits
   context from it’s creator (<code>about:blank</code>, <code>about:srcdoc</code>, <code>data</code>) or one whose <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin">origin</a> is a <a data-link-type="dfn" href="#potentially-trustworthy-origin" id="ref-for-potentially-trustworthy-origin②">potentially trustworthy origin</a>.
@@ -2197,13 +2168,13 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   than a speed-bump, slowing down non-secure access to the API, but completely
   ineffective in preventing such access.</p>
     <p>While the algorithms in this document do not perfectly isolate non-secure
-  contexts from <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②⑤">secure contexts</a> (as discussed in <a href="#isolation">§ 5.1 Incomplete Isolation</a>), the
+  contexts from <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②④">secure contexts</a> (as discussed in <a href="#isolation">§ 5.1 Incomplete Isolation</a>), the
   ancestor checks provide a fairly robust protection for the guarantees of
   authentication, confidentiality, and integrity that such contexts ought to
   provide.</p>
     <h3 class="heading settled" data-level="4.3" id="threat-risks"><span class="secno">4.3. </span><span class="content">Risks associated with non-secure contexts</span><a class="self-link" href="#threat-risks"></a></h3>
     <p>Certain web platform features that have a distinct impact on a user’s
-  security or privacy should be available for use only in <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②⑥">secure
+  security or privacy should be available for use only in <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②⑤">secure
   contexts</a> in order to defend against the threats above. Features
   available in non-secure contexts risk exposing these capabilities to
   network attackers:</p>
@@ -2233,7 +2204,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     </ol>
     <p>This list is non-exhaustive, but should give you a feel for the types of
   risks we should consider when writing or implementing specifications.</p>
-    <p class="note" role="note"><span>Note:</span> While restricting a feature itself to <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②⑦">secure contexts</a> is
+    <p class="note" role="note"><span>Note:</span> While restricting a feature itself to <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②⑥">secure contexts</a> is
   critical, we ought not forget that facilities that carry such information
   (such as new network access mechanisms, or other generic functions with access
   to network data) are equally sensitive.</p>
@@ -2241,7 +2212,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <section>
     <h2 class="heading settled" data-level="5" id="security-considerations"><span class="secno">5. </span><span class="content">Security Considerations</span><a class="self-link" href="#security-considerations"></a></h2>
     <h3 class="heading settled" data-level="5.1" id="isolation"><span class="secno">5.1. </span><span class="content">Incomplete Isolation</span><a class="self-link" href="#isolation"></a></h3>
-    <p>The <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②⑧">secure context</a> definition in this document does not completely
+    <p>The <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②⑦">secure context</a> definition in this document does not completely
   isolate a "secure" view on an origin from a "non-secure" view on the same
   origin. Exfiltration will still be possible via increasingly esoteric
   mechanisms such as the contents of <code>localStorage</code>/<code>sessionStorage</code>, <code>storage</code> events, <code>BroadcastChannel</code>, and others.</p>
@@ -2257,7 +2228,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    </section>
    <section>
     <h2 class="heading settled" data-level="6" id="privacy-considerations"><span class="secno">6. </span><span class="content">Privacy Considerations</span><a class="self-link" href="#privacy-considerations"></a></h2>
-    <p>The <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②⑨">secure context</a> definition in this document does not in itself have
+    <p>The <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②⑧">secure context</a> definition in this document does not in itself have
   any privacy impact. It does, however, enable other features which do have
   interesting privacy implications to lock themselves into contexts which
   ensures that specific guarantees can be made regarding integrity,
@@ -2281,13 +2252,13 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <h3 class="heading settled" data-level="7.3" id="new"><span class="secno">7.3. </span><span class="content">Restricting New Features</span><a class="self-link" href="#new"></a></h3>
     <p><em>This section is non-normative.</em></p>
     <p>When writing a specification for new features, we recommend that authors
-  and editors guard sensitive APIs with checks against <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts③⓪">secure contexts</a>.
+  and editors guard sensitive APIs with checks against <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts②⑨">secure contexts</a>.
   For example, something like the following might be a good approach:</p>
     <div class="example" id="example-0fe6ea9a">
      <a class="self-link" href="#example-0fe6ea9a"></a> 
      <ol>
       <li>
-        If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object">current settings object</a> is <em>not</em> a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts③①">secure
+        If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object">current settings object</a> is <em>not</em> a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts③⓪">secure
         context</a>, then: 
        <ol>
         <li> [<i>insert something appropriate here: perhaps a Promise could be
@@ -2296,7 +2267,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
        </ol>
      </ol>
     </div>
-    <p>Authors could alternatively ensure that sensitive APIs are only exposed to <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts③②">secure contexts</a> by guarding them with the [<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext④">SecureContext</a></code>] attribute.</p>
+    <p>Authors could alternatively ensure that sensitive APIs are only exposed to <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts③①">secure contexts</a> by guarding them with the [<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext④">SecureContext</a></code>] attribute.</p>
     <div class="example" id="example-2aa4b56a">
      <a class="self-link" href="#example-2aa4b56a"></a> 
 <pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext⑤"><c- g>SecureContext</c-></a>]
@@ -2316,16 +2287,16 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <p><em>This section is non-normative.</em></p>
      <p>The list above clearly includes some existing functionality that is currently
     available to the web over non-secure channels. We recommend that such legacy
-    functionality be modified to begin requiring a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts③③">secure context</a> as
+    functionality be modified to begin requiring a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts③②">secure context</a> as
     quickly as is reasonably possible <a data-link-type="biblio" href="#biblio-w3c-process">[W3C-PROCESS]</a>.</p>
      <ol>
       <li data-md>
        <p>If such a feature is not widely implemented, we recommend that the
   specification be immediately <a data-link-type="dfn" href="https://www.w3.org/2017/Process-20170301/#rec-modify" id="ref-for-rec-modify">modified</a> to include a restriction
-  to <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts③④">secure contexts</a>.</p>
+  to <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts③③">secure contexts</a>.</p>
       <li data-md>
        <p>If such a feature is widely implemented, but not yet in wide use, we
-  recommend that it be quickly restricted to <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts③⑤">secure contexts</a> by
+  recommend that it be quickly restricted to <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts③④">secure contexts</a> by
   adding a check as described in <a href="#new">§ 7.3 Restricting New Features</a> to existing implementations, and <a data-link-type="dfn" href="https://www.w3.org/2017/Process-20170301/#rec-modify" id="ref-for-rec-modify①">modifying the specification</a> accordingly.</p>
       <li data-md>
        <p>If such a feature is in wide use, we recommend that the existing
@@ -2341,8 +2312,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <ol>
       <li data-md>
        <p><a data-link-type="dfn" href="https://www.w3.org/2017/Process-20170301/#rec-modify" id="ref-for-rec-modify③">Modify</a> the specification to include
-  checks against <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts③⑥">secure context</a> before executing the algorithms for <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/geolocation-API/#get-current-position" id="ref-for-get-current-position">getCurrentPosition()</a></code> and <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/geolocation-API/#watch-position" id="ref-for-watch-position">watchPosition()</a></code>.</p>
-       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object①">current settings object</a> is not a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts③⑦">secure context</a>,
+  checks against <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts③⑤">secure context</a> before executing the algorithms for <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/geolocation-API/#get-current-position" id="ref-for-get-current-position">getCurrentPosition()</a></code> and <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/geolocation-API/#watch-position" id="ref-for-watch-position">watchPosition()</a></code>.</p>
+       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object" id="ref-for-current-settings-object①">current settings object</a> is not a <a data-link-type="dfn" href="#secure-contexts" id="ref-for-secure-contexts③⑥">secure context</a>,
   then the algorithm should be aborted, and the <code>errorCallback</code> invoked with a <code>code</code> of <code>PERMISSION_DENIED</code>.</p>
       <li data-md>
        <p>The user agent should announce clear intentions to disable the API for
@@ -2410,14 +2381,12 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#attr-valuedef-iframe-sandbox-allow-secure-context">allow-secure-context</a><span>, in §2.2.1</span>
    <li><a href="#environment-settings-object-contextually-secure">contextually secure</a><span>, in §3.1</span>
    <li><a href="#settings-object">Is an environment settings object contextually secure?</a><span>, in §3.1</span>
-   <li><a href="#dom-windoworworkerglobalscope-issecurecontext">isSecureContext</a><span>, in §2.2.3</span>
+   <li><a href="#dom-windoworworkerglobalscope-issecurecontext">isSecureContext</a><span>, in §2.2.2</span>
    <li><a href="#non-secure-contexts">non-secure contexts</a><span>, in §2</span>
    <li><a href="#potentially-trustworthy-origin">potentially trustworthy origin</a><span>, in §3.2</span>
    <li><a href="#potentially-trustworthy-url">potentially trustworthy URL</a><span>, in §3.3</span>
-   <li><a href="#sandboxed-secure-browsing-context-flag">sandboxed secure browsing context flag</a><span>, in §2.2.1</span>
    <li><a href="#secure-contexts">secure contexts</a><span>, in §2</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-document">
@@ -2442,7 +2411,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <aside class="dfn-panel" data-for="term-for-sharedworker">
    <a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker">https://html.spec.whatwg.org/multipage/workers.html#sharedworker</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-sharedworker">2.2.2. Shared Workers</a>
+    <li><a href="#ref-for-sharedworker">2.2.1. Shared Workers</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-window">
@@ -2456,7 +2425,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <aside class="dfn-panel" data-for="term-for-windoworworkerglobalscope">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-windoworworkerglobalscope">2.2.3. Feature Detection</a>
+    <li><a href="#ref-for-windoworworkerglobalscope">2.2.2. Feature Detection</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-workerglobalscope">
@@ -2478,13 +2447,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <a href="https://html.spec.whatwg.org/multipage/origin.html#active-sandboxing-flag-set">https://html.spec.whatwg.org/multipage/origin.html#active-sandboxing-flag-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-sandboxing-flag-set">3.1. 
-    Is an environment settings object contextually secure? </a> <a href="#ref-for-active-sandboxing-flag-set①">(2)</a> <a href="#ref-for-active-sandboxing-flag-set②">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-browsing-context">2.2.1. Sandboxing</a>
+    Is an environment settings object contextually secure? </a> <a href="#ref-for-active-sandboxing-flag-set①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-environment-creation-url">
@@ -2571,12 +2534,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     Is an environment settings object contextually secure? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-sandboxing-directive">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive">https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-parse-a-sandboxing-directive">2.2.1. Sandboxing</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-concept-origin-port">
    <a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-port">https://html.spec.whatwg.org/multipage/origin.html#concept-origin-port</a><b>Referenced in:</b>
    <ul>
@@ -2588,7 +2545,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">2. Framework</a>
-    <li><a href="#ref-for-relevant-settings-object①">2.2.3. Feature Detection</a>
+    <li><a href="#ref-for-relevant-settings-object①">2.2.2. Feature Detection</a>
     <li><a href="#ref-for-relevant-settings-object②">3.1. 
     Is an environment settings object contextually secure? </a> <a href="#ref-for-relevant-settings-object③">(2)</a> <a href="#ref-for-relevant-settings-object④">(3)</a> <a href="#ref-for-relevant-settings-object⑤">(4)</a>
    </ul>
@@ -2677,7 +2634,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <aside class="dfn-panel" data-for="term-for-idl-boolean">
    <a href="https://heycam.github.io/webidl/#idl-boolean">https://heycam.github.io/webidl/#idl-boolean</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-boolean">2.2.3. Feature Detection</a>
+    <li><a href="#ref-for-idl-boolean">2.2.2. Feature Detection</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-exposed">
@@ -2708,7 +2665,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <li><span class="dfn-paneled" id="term-for-workerglobalscope" style="color:initial">WorkerGlobalScope</span>
      <li><span class="dfn-paneled" id="term-for-active-document" style="color:initial">active document</span>
      <li><span class="dfn-paneled" id="term-for-active-sandboxing-flag-set" style="color:initial">active sandboxing flag set</span>
-     <li><span class="dfn-paneled" id="term-for-browsing-context" style="color:initial">browsing context</span>
      <li><span class="dfn-paneled" id="term-for-concept-environment-creation-url" style="color:initial">creation url</span>
      <li><span class="dfn-paneled" id="term-for-current-settings-object" style="color:initial">current settings object</span>
      <li><span class="dfn-paneled" id="term-for-concept-origin-domain" style="color:initial">domain</span>
@@ -2721,7 +2677,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <li><span class="dfn-paneled" id="term-for-concept-settings-object-origin" style="color:initial">origin <small>(for environment settings object)</small></span>
      <li><span class="dfn-paneled" id="term-for-concept-WorkerGlobalScope-owner-set" style="color:initial">owner set</span>
      <li><span class="dfn-paneled" id="term-for-parent-browsing-context" style="color:initial">parent browsing context</span>
-     <li><span class="dfn-paneled" id="term-for-parse-a-sandboxing-directive" style="color:initial">parse a sandboxing directive</span>
      <li><span class="dfn-paneled" id="term-for-concept-origin-port" style="color:initial">port</span>
      <li><span class="dfn-paneled" id="term-for-relevant-settings-object" style="color:initial">relevant settings object</span>
      <li><span class="dfn-paneled" id="term-for-responsible-document" style="color:initial">responsible document</span>
@@ -2822,11 +2777,6 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 </pre>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
-   <div class="issue"> This feature is "at risk", pending the
-    resolution of the linked issue (which itself is pending metrics gathered from
-    browser vendors). Accordingly, no attempt has been made to upstream this to
-    either WHATWG’s HTML or W3C’s HTML. Once we’ve decided whether or not to keep
-    the feature, we’ll work on that. <a href="https://github.com/w3c/webappsec-secure-contexts/issues/28">&lt;https://github.com/w3c/webappsec-secure-contexts/issues/28></a><a href="#issue-7a8465db"> ↵ </a></div>
    <div class="issue"> This is currently defined in Step 11.4.2 of the WHATWG’s HTML (landed in <a href="https://github.com/whatwg/html/pull/1560">whatwg/html#1560</a>. It has not yet been
     picked up by the W3C’s version of that algorithm. <a href="https://github.com/w3c/workers/issues/6">&lt;https://github.com/w3c/workers/issues/6></a><a href="#issue-84914d73"> ↵ </a></div>
    <div class="issue"> Upstream this to HTML.<a href="#issue-10e3374e"> ↵ </a></div>
@@ -2840,48 +2790,38 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-secure-contexts⑨">1.4. Shared Workers</a> <a href="#ref-for-secure-contexts①⓪">(2)</a> <a href="#ref-for-secure-contexts①①">(3)</a> <a href="#ref-for-secure-contexts①②">(4)</a>
     <li><a href="#ref-for-secure-contexts①③">1.5. Service Workers</a> <a href="#ref-for-secure-contexts①④">(2)</a> <a href="#ref-for-secure-contexts①⑤">(3)</a>
     <li><a href="#ref-for-secure-contexts①⑥">2. Framework</a>
-    <li><a href="#ref-for-secure-contexts①⑦">2.2.1. Sandboxing</a>
-    <li><a href="#ref-for-secure-contexts①⑧">2.2.2. Shared Workers</a> <a href="#ref-for-secure-contexts①⑨">(2)</a> <a href="#ref-for-secure-contexts②⓪">(3)</a>
-    <li><a href="#ref-for-secure-contexts②①">2.2.3. Feature Detection</a>
-    <li><a href="#ref-for-secure-contexts②②">3.1. 
-    Is an environment settings object contextually secure? </a> <a href="#ref-for-secure-contexts②③">(2)</a>
-    <li><a href="#ref-for-secure-contexts②④">3.2. 
+    <li><a href="#ref-for-secure-contexts①⑦">2.2.1. Shared Workers</a> <a href="#ref-for-secure-contexts①⑧">(2)</a> <a href="#ref-for-secure-contexts①⑨">(3)</a>
+    <li><a href="#ref-for-secure-contexts②⓪">2.2.2. Feature Detection</a>
+    <li><a href="#ref-for-secure-contexts②①">3.1. 
+    Is an environment settings object contextually secure? </a> <a href="#ref-for-secure-contexts②②">(2)</a>
+    <li><a href="#ref-for-secure-contexts②③">3.2. 
     Is origin potentially trustworthy? </a>
-    <li><a href="#ref-for-secure-contexts②⑤">4.2. Ancestral Risk</a>
-    <li><a href="#ref-for-secure-contexts②⑥">4.3. Risks associated with non-secure contexts</a> <a href="#ref-for-secure-contexts②⑦">(2)</a>
-    <li><a href="#ref-for-secure-contexts②⑧">5.1. Incomplete Isolation</a>
-    <li><a href="#ref-for-secure-contexts②⑨">6. Privacy Considerations</a>
-    <li><a href="#ref-for-secure-contexts③⓪">7.3. Restricting New Features</a> <a href="#ref-for-secure-contexts③①">(2)</a> <a href="#ref-for-secure-contexts③②">(3)</a>
-    <li><a href="#ref-for-secure-contexts③③">7.4. Restricting Legacy Features</a> <a href="#ref-for-secure-contexts③④">(2)</a> <a href="#ref-for-secure-contexts③⑤">(3)</a>
-    <li><a href="#ref-for-secure-contexts③⑥">7.4.1. Example: Geolocation</a> <a href="#ref-for-secure-contexts③⑦">(2)</a>
+    <li><a href="#ref-for-secure-contexts②④">4.2. Ancestral Risk</a>
+    <li><a href="#ref-for-secure-contexts②⑤">4.3. Risks associated with non-secure contexts</a> <a href="#ref-for-secure-contexts②⑥">(2)</a>
+    <li><a href="#ref-for-secure-contexts②⑦">5.1. Incomplete Isolation</a>
+    <li><a href="#ref-for-secure-contexts②⑧">6. Privacy Considerations</a>
+    <li><a href="#ref-for-secure-contexts②⑨">7.3. Restricting New Features</a> <a href="#ref-for-secure-contexts③⓪">(2)</a> <a href="#ref-for-secure-contexts③①">(3)</a>
+    <li><a href="#ref-for-secure-contexts③②">7.4. Restricting Legacy Features</a> <a href="#ref-for-secure-contexts③③">(2)</a> <a href="#ref-for-secure-contexts③④">(3)</a>
+    <li><a href="#ref-for-secure-contexts③⑤">7.4.1. Example: Geolocation</a> <a href="#ref-for-secure-contexts③⑥">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="non-secure-contexts">
    <b><a href="#non-secure-contexts">#non-secure-contexts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-secure-contexts">2. Framework</a>
-    <li><a href="#ref-for-non-secure-contexts①">2.2.1. Sandboxing</a> <a href="#ref-for-non-secure-contexts②">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="sandboxed-secure-browsing-context-flag">
-   <b><a href="#sandboxed-secure-browsing-context-flag">#sandboxed-secure-browsing-context-flag</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-sandboxed-secure-browsing-context-flag①">2.2.1. Sandboxing</a>
-    <li><a href="#ref-for-sandboxed-secure-browsing-context-flag②">3.1. 
-    Is an environment settings object contextually secure? </a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-windoworworkerglobalscope-issecurecontext">
    <b><a href="#dom-windoworworkerglobalscope-issecurecontext">#dom-windoworworkerglobalscope-issecurecontext</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-windoworworkerglobalscope-issecurecontext">2.2.3. Feature Detection</a>
+    <li><a href="#ref-for-dom-windoworworkerglobalscope-issecurecontext">2.2.2. Feature Detection</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="environment-settings-object-contextually-secure">
    <b><a href="#environment-settings-object-contextually-secure">#environment-settings-object-contextually-secure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object-contextually-secure">2. Framework</a> <a href="#ref-for-environment-settings-object-contextually-secure①">(2)</a>
-    <li><a href="#ref-for-environment-settings-object-contextually-secure②">2.2.3. Feature Detection</a>
+    <li><a href="#ref-for-environment-settings-object-contextually-secure②">2.2.2. Feature Detection</a>
     <li><a href="#ref-for-environment-settings-object-contextually-secure③">3.1. 
     Is an environment settings object contextually secure? </a> <a href="#ref-for-environment-settings-object-contextually-secure④">(2)</a>
    </ul>

--- a/index.src.html
+++ b/index.src.html
@@ -18,7 +18,6 @@ Version History: https://github.com/w3c/webappsec-secure-contexts/commits/master
 Indent: 2
 Markup Shorthands: markdown on
 Boilerplate: omit conformance, omit feedback-header
-At Risk: The <a>sandboxed secure browsing context flag</a> defined in [[#monkey-patching-sandbox-flags]], as well as its usage in [[#is-settings-object-contextually-secure]].
 </pre>
 <pre class="link-defaults">
 spec:url; type:interface; text:URL
@@ -507,35 +506,6 @@ urlPrefix: https://www.w3.org/2017/Process-20170301/; spec: W3C-PROCESS
 
     <h3 id="monkey-patching-html">Modifications to HTML</h3>
 
-    <h4 id="monkey-patching-sandbox-flags">Sandboxing</h4>
-
-    Developers may wish to treat sandboxed <a for="/">browsing contexts</a> as <a>secure
-    contexts</a> in some situations, and <a>non-secure contexts</a> in others. The
-    following sandboxing flag supports this desire:
-
-    <dl>
-      <dt>The <dfn export>sandboxed secure browsing context flag</dfn></dt>
-      <dd>
-        This flag asserts that content in a browsing context will be treated as a
-        <a>non-secure context</a>, even if it would otherwise be considered secure.
-      </dd>
-    </dl>
-
-    The <a>parse a sandboxing directive</a> algorithm is extended by adding the
-    following entry to the list in the final step of the algorithm which parses
-    |tokens| into flags:
-
-    *   The <a>sandboxed secure browsing context flag</a>, unless |tokens|
-        contains the
-        <dfn attr-value for="iframe/sandbox" export>`allow-secure-context`</dfn>
-        keyword.
-
-    ISSUE(w3c/webappsec-secure-contexts#28): This feature is "at risk", pending the
-    resolution of the linked issue (which itself is pending metrics gathered from
-    browser vendors). Accordingly, no attempt has been made to upstream this to
-    either WHATWG's HTML or W3C's HTML. Once we've decided whether or not to keep
-    the feature, we'll work on that.
-
     <h4 id="shared-workers" class="non-normative">Shared Workers</h4>
 
     <em>This section is non-normative</em>.
@@ -608,18 +578,12 @@ urlPrefix: https://www.w3.org/2017/Process-20170301/; spec: W3C-PROCESS
 
     5.  Return "`Not Secure`" if any of the following are true:
 
-        1.  |document|'s <a for=Document>active sandboxing flag set</a> contains the
-            <a>sandboxed secure browsing context flag</a>.
-
-            Note: This check is "at risk". See [[#monkey-patching-sandbox-flags]]
-            for details.
-
-        2.  |document| has a [=parent browsing context=] (|context|), and |context|'s
+        1.  |document| has a [=parent browsing context=] (|context|), and |context|'s
             [=active document=]'s [=relevant settings object=] is not [=contextually secure=].
 
-        3.  |settings|'s <a for="environment settings object">HTTPS state</a> is "`deprecated`".
+        2.  |settings|'s <a for="environment settings object">HTTPS state</a> is "`deprecated`".
 
-        4.  |document|'s <a for=Document>active sandboxing flag set</a> includes the
+        3.  |document|'s <a for=Document>active sandboxing flag set</a> includes the
             <a>sandboxed origin browsing context flag</a>, and
             [[#is-url-trustworthy]] returns "`Not Trustworthy`" when executed upon
             |settings|'s <a>creation URL</a>.
@@ -633,7 +597,7 @@ urlPrefix: https://www.w3.org/2017/Process-20170301/; spec: W3C-PROCESS
             look at the origin of its URL to determine whether we would have
             considered it trustworthy had it not been sandboxed.
 
-        5.  |document|'s <a for=Document>active sandboxing flag set</a> does not include the
+        4.  |document|'s <a for=Document>active sandboxing flag set</a> does not include the
             <a>sandboxed origin browsing context flag</a>, and
             [[#is-origin-trustworthy]] returns "`Not Trustworthy`" when executed
             upon |settings|'s <a for="environment settings object">origin</a>.


### PR DESCRIPTION
Closes https://github.com/w3c/webappsec-secure-contexts/issues/28, again.

Tested in https://wpt.fyi/results/secure-contexts/basic-popup-and-iframe-tests.html?label=master&label=experimental&aligned, showing that no one ever shipped this.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-secure-contexts/pull/73.html" title="Last updated on Feb 14, 2020, 10:40 AM UTC (339d04a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-secure-contexts/73/a05fd1f...339d04a.html" title="Last updated on Feb 14, 2020, 10:40 AM UTC (339d04a)">Diff</a>