### PR TITLE
Improve origin trustworthiness algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -1323,7 +1323,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 89ebb6ab, updated Fri Oct 9 15:32:07 2020 -0700" name="generator">
   <link href="https://www.w3.org/TR/secure-contexts/" rel="canonical">
-  <meta content="533cc15ab77c65d70bb2a56a09274f2088b2f939" name="document-revision">
+  <meta content="683732dc245605cdcaf79716ab3ede1543155aeb" name="document-revision">
 <style>
     .secure {
       fill: #8F8;
@@ -2430,15 +2430,20 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   return "<code>Potentially Trustworthy</code>".</p>
       <p class="note" role="note"><span>Note:</span> This is meant to be analog to the <a data-link-type="dfn" href="https://w3c.github.io/webappsec-mixed-content/#a-priori-authenticated-url" id="ref-for-a-priori-authenticated-url"><i lang="la">a priori</i> authenticated URL</a> concept in <a data-link-type="biblio" href="#biblio-mix">[MIX]</a>.</p>
      <li data-md>
-      <p>If <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host" id="ref-for-concept-origin-host">host</a> component matches one of the CIDR
+      <p>If <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host" id="ref-for-concept-origin-host">host</a> matches one of the CIDR
   notations <code>127.0.0.0/8</code> or <code>::1/128</code> <a data-link-type="biblio" href="#biblio-rfc4632">[RFC4632]</a>, return "<code>Potentially Trustworthy</code>".</p>
      <li data-md>
-      <p>If <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host" id="ref-for-concept-origin-host①">host</a> component is "<code>localhost</code>" or
-  falls within "<code>.localhost</code>", and the user agent conforms to the name
-  resolution rules in <a data-link-type="biblio" href="#biblio-let-localhost-be-localhost">[let-localhost-be-localhost]</a>, return "<code>Potentially Trustworthy</code>".</p>
+      <p>If the user agent conforms to the name resolution rules in <a data-link-type="biblio" href="#biblio-let-localhost-be-localhost">[let-localhost-be-localhost]</a> and one of the following is true:</p>
+      <ul>
+       <li data-md>
+        <p><var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host" id="ref-for-concept-origin-host①">host</a> is "<code>localhost</code>" or "<code>localhost.</code>"</p>
+       <li data-md>
+        <p><var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host" id="ref-for-concept-origin-host②">host</a> ends with "<code>.localhost</code>" or "<code>.localhost.</code>"</p>
+      </ul>
+      <p>then return "<code>Potentially Trustworthy</code>".</p>
       <p class="note" role="note"><span>Note:</span> See <a href="#localhost">§ 5.2 localhost</a> for details on the requirements here.</p>
      <li data-md>
-      <p>If <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme①">scheme</a> component is <code>file</code>, return
+      <p>If <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme①">scheme</a> is "<code>file</code>", return
   "<code>Potentially Trustworthy</code>".</p>
      <li data-md>
       <p>If <var>origin</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-scheme" id="ref-for-concept-origin-scheme②">scheme</a> component is one which the user
@@ -2782,7 +2787,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host">https://html.spec.whatwg.org/multipage/origin.html#concept-origin-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-host">3.1. 
-    Is origin potentially trustworthy? </a> <a href="#ref-for-concept-origin-host①">(2)</a>
+    Is origin potentially trustworthy? </a> <a href="#ref-for-concept-origin-host①">(2)</a> <a href="#ref-for-concept-origin-host②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-the-iframe-element">

--- a/index.html
+++ b/index.html
@@ -1323,7 +1323,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 89ebb6ab, updated Fri Oct 9 15:32:07 2020 -0700" name="generator">
   <link href="https://www.w3.org/TR/secure-contexts/" rel="canonical">
-  <meta content="683732dc245605cdcaf79716ab3ede1543155aeb" name="document-revision">
+  <meta content="a08a5d67897dc88cca8ab52f6dbb4e3cbbfd7e1e" name="document-revision">
 <style>
     .secure {
       fill: #8F8;

--- a/index.src.html
+++ b/index.src.html
@@ -563,18 +563,22 @@ urlPrefix: https://www.w3.org/2017/Process-20170301/; spec: W3C-PROCESS
       Note: This is meant to be analog to the <a><i lang="la">a priori</i>
       authenticated URL</a> concept in [[MIX]].
 
-  4.  If |origin|'s <a for="origin">host</a> component matches one of the CIDR
+  4.  If |origin|'s <a for="origin">host</a> matches one of the CIDR
       notations `127.0.0.0/8` or `::1/128` [[!RFC4632]], return "`Potentially
       Trustworthy`".
 
-  5.  If |origin|'s <a for="origin">host</a> component is "`localhost`" or
-      falls within "`.localhost`", and the user agent conforms to the name
-      resolution rules in [[!let-localhost-be-localhost]], return "`Potentially
-      Trustworthy`".
+  5.  If the user agent conforms to the name resolution rules in
+      [[!let-localhost-be-localhost]] and one of the following is true:
+
+      * |origin|'s <a for="origin">host</a> is "`localhost`" or "`localhost.`"
+
+      * |origin|'s <a for="origin">host</a> ends with "`.localhost`" or "`.localhost.`"
+
+      then return "`Potentially Trustworthy`".
 
       Note: See [[#localhost]] for details on the requirements here.
 
-  6.  If |origin|'s <a for="origin">scheme</a> component is `file`, return
+  6.  If |origin|'s <a for="origin">scheme</a> is "`file`", return
       "`Potentially Trustworthy`".
 
   7.  If |origin|'s <a for="origin">scheme</a> component is one which the user


### PR DESCRIPTION
In particular make it clear that localhost can have a trailing dot


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-secure-contexts/pull/77.html" title="Last updated on Jan 12, 2021, 8:31 AM UTC (bb295a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-secure-contexts/77/683732d...bb295a7.html" title="Last updated on Jan 12, 2021, 8:31 AM UTC (bb295a7)">Diff</a>