### PR TITLE
Fix typo in example description

### DIFF
--- a/index.html
+++ b/index.html
@@ -1323,7 +1323,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 89ebb6ab, updated Fri Oct 9 15:32:07 2020 -0700" name="generator">
   <link href="https://www.w3.org/TR/secure-contexts/" rel="canonical">
-  <meta content="a08a5d67897dc88cca8ab52f6dbb4e3cbbfd7e1e" name="document-revision">
+  <meta content="16a7e751c6b4ea1f0d707a96ee64952b398e05d1" name="document-revision">
 <style>
     .secure {
       fill: #8F8;
@@ -2106,10 +2106,10 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
       </g>
      </svg>
     </div>
-    <div class="example" id="example-4ec7a126">
-     <a class="self-link" href="#example-4ec7a126"></a> 
+    <div class="example" id="example-b1ac2704">
+     <a class="self-link" href="#example-b1ac2704"></a> 
      <p>Likewise, if a non-secure context opens <code>https://example.com/</code> in a new window,
-    that new window will be a secure context, even through its opener was non-secure:</p>
+    that new window will be a secure context, even though its opener was non-secure:</p>
      <svg height="400" width="400">
       <g transform="translate(10,10)">
        <rect class="non-secure" height="175" width="297" x="0" y="0"></rect>

--- a/index.html
+++ b/index.html
@@ -1323,7 +1323,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 89ebb6ab, updated Fri Oct 9 15:32:07 2020 -0700" name="generator">
   <link href="https://www.w3.org/TR/secure-contexts/" rel="canonical">
-  <meta content="16a7e751c6b4ea1f0d707a96ee64952b398e05d1" name="document-revision">
+  <meta content="76f42173e9398f04b88026365762ee758a808110" name="document-revision">
 <style>
     .secure {
       fill: #8F8;
@@ -2106,8 +2106,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
       </g>
      </svg>
     </div>
-    <div class="example" id="example-b1ac2704">
-     <a class="self-link" href="#example-b1ac2704"></a> 
+    <div class="example" id="example-4ec7a126">
+     <a class="self-link" href="#example-4ec7a126"></a> 
      <p>Likewise, if a non-secure context opens <code>https://example.com/</code> in a new window,
     that new window will be a secure context, even though its opener was non-secure:</p>
      <svg height="400" width="400">

--- a/index.src.html
+++ b/index.src.html
@@ -181,7 +181,7 @@ urlPrefix: https://www.w3.org/2017/Process-20170301/; spec: W3C-PROCESS
 
   <div class="example">
     <p>Likewise, if a non-secure context opens <code>https://example.com/</code> in a new window,
-    that new window will be a secure context, even through its opener was non-secure:</p>
+    that new window will be a secure context, even though its opener was non-secure:</p>
 
     <svg width="400" height="400">
       <g transform="translate(10,10)">

--- a/index.src.html
+++ b/index.src.html
@@ -179,7 +179,7 @@ urlPrefix: https://www.w3.org/2017/Process-20170301/; spec: W3C-PROCESS
     </svg>
   </div>
 
-  <div class="example">
+  <div class="example" id="example-4ec7a126">
     <p>Likewise, if a non-secure context opens <code>https://example.com/</code> in a new window,
     that new window will be a secure context, even though its opener was non-secure:</p>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/CYBAI/webappsec-secure-contexts/pull/80.html" title="Last updated on Jan 12, 2021, 8:35 AM UTC (368eb8e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-secure-contexts/80/24b4c18...CYBAI:368eb8e.html" title="Last updated on Jan 12, 2021, 8:35 AM UTC (368eb8e)">Diff</a>