### PR TITLE
Remove reference to "filesystem:" scheme from a note.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2468,7 +2468,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
       <p>If <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is "<code>data</code>", return "<code>Potentially Trustworthy</code>".</p>
      <li data-md>
       <p>Return the result of executing <a href="#is-origin-trustworthy">§ 3.1 Is origin potentially trustworthy?</a> on <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin" id="ref-for-concept-url-origin①">origin</a>.</p>
-      <p class="note" role="note"><span>Note:</span> The origin of <code>blob:</code> and <code>filesystem:</code> URLs is the origin of the
+      <p class="note" role="note"><span>Note:</span> The origin of <code>blob:</code> URLs is the origin of the
   context in which they were created. Therefore, blobs created in a
   trustworthy origin will themselves be potentially trustworthy.</p>
     </ol>

--- a/index.src.html
+++ b/index.src.html
@@ -615,7 +615,7 @@ urlPrefix: https://www.w3.org/2017/Process-20170301/; spec: W3C-PROCESS
   3.  Return the result of executing [[#is-origin-trustworthy]] on |url|'s
       <a for="url">origin</a>.
 
-      Note: The origin of `blob:` and `filesystem:` URLs is the origin of the
+      Note: The origin of `blob:` URLs is the origin of the
       context in which they were created. Therefore, blobs created in a
       trustworthy origin will themselves be potentially trustworthy.
 </section>


### PR DESCRIPTION
This is proprietary feature and Chromium does not plan to push for
adoption [1]. The HTML spec treats the origin of an URL with such a
scheme as opaque [2]. This only seems to be mentioned in a
(non-normative) note, so it is safe to just remove it to avoid any
confusion. Also this does not really match the "Therefore, blobs..."
in the next sentence.

[1] https://groups.google.com/a/chromium.org/g/blink-dev/c/nrpl_ewkmaQ/m/mmpummdqBAAJ
[2] https://url.spec.whatwg.org/#concept-url-origin


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fred-wang/webappsec-secure-contexts/pull/89.html" title="Last updated on Apr 30, 2021, 12:00 PM UTC (21b8388)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-secure-contexts/89/213c342...fred-wang:21b8388.html" title="Last updated on Apr 30, 2021, 12:00 PM UTC (21b8388)">Diff</a>