### PR TITLE
Mark 'is origin trustworth' as exported definition of an algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -525,7 +525,7 @@ urlPrefix: https://www.w3.org/2017/Process-20170301/; spec: W3C-PROCESS
 <section>
   <h2 id="algorithms">Algorithms</h2>
 
-  <h3 dfn-type="algorithm" export id="is-origin-trustworthy">
+  <h3 abstract-op export id="is-origin-trustworthy">
     Is |origin| potentially trustworthy?
   </h3>
 

--- a/index.bs
+++ b/index.bs
@@ -525,7 +525,7 @@ urlPrefix: https://www.w3.org/2017/Process-20170301/; spec: W3C-PROCESS
 <section>
   <h2 id="algorithms">Algorithms</h2>
 
-  <h3 id="is-origin-trustworthy">
+  <h3 dfn-type="algorithm" export id="is-origin-trustworthy">
     Is |origin| potentially trustworthy?
   </h3>
 


### PR DESCRIPTION
used in https://w3c.github.io/network-error-logging/